### PR TITLE
Use statistic figures

### DIFF
--- a/mclogalyzer/mclogalyzer.py
+++ b/mclogalyzer/mclogalyzer.py
@@ -199,7 +199,7 @@ class UserStats:
             playtime[date-start_date]                            = self._day_activity[date]
             weektime[datetime.date.fromordinal(date).weekday()] += self._day_activity[date]
 
-        # playtime by day (all history)
+        # playtime by day 
         pylab.plot(date_tag, playtime)
         pylab.setp(pylab.xticks()[1], rotation=20)
         pylab.gca().xaxis.set_major_formatter(matplotlib.dates.DateFormatter('%b %d %Y'))
@@ -207,29 +207,6 @@ class UserStats:
         pylab.ylabel('Minutes played');
         pylab.title('Play minutes per day')
         pylab.savefig('img/'+self._username+'_day_history.png')
-        pylab.clf()
-
-        # playtime by day (current month)
-        pylab.plot(date_tag[-n_month:], playtime[-n_month:])
-        pylab.setp(pylab.xticks()[1], rotation=20)
-        pylab.gca().xaxis.set_major_formatter(matplotlib.dates.DateFormatter('%b %d %Y'))
-        pylab.xlabel('Date');
-        pylab.ylabel('Minutes played');
-        pylab.title('Play minutes per day this month')
-        pylab.savefig('img/'+self._username+'_day_month.png')
-        pylab.clf()
-
-        # playtime by day (current week)
-        pylab.plot(date_tag[-n_week:], playtime[-n_week:])
-        pylab.setp(pylab.xticks()[1], rotation=20)
-        pylab.gca().xaxis.set_major_formatter(matplotlib.dates.DateFormatter('%b %d %Y'))
-        pylab.gca().xaxis.set_major_locator(matplotlib.ticker.MaxNLocator(n_week+1))
-        pylab.gca().xaxis.set_minor_locator(matplotlib.ticker.MaxNLocator(1))
-        matplotlib.ticker.MaxNLocator
-        pylab.xlabel('Date');
-        pylab.ylabel('Minutes played');
-        pylab.title('Play minutes per day this week')
-        pylab.savefig('img/'+self._username+'_day_week.png')
         pylab.clf()
 
         # plot weekday pie chart
@@ -442,7 +419,7 @@ class ServerStats:
         pylab.savefig('img/server_day_history.png')
         pylab.clf()
 
-        # active users by day (all history)
+        # active users by day 
         pylab.plot(date_tag, users, 'm-')
         pylab.setp(pylab.xticks()[1], rotation=20)
         pylab.gca().xaxis.set_major_formatter(matplotlib.dates.DateFormatter('%b %d %Y'))
@@ -460,29 +437,6 @@ class ServerStats:
         pylab.ylabel('PvP Kills');
         pylab.title('Server hostility: PvP kills per day')
         pylab.savefig('img/server_day_pvp.png')
-        pylab.clf()
-
-        # playtime by day (current month)
-        pylab.plot(date_tag[-n_month:], playtime[-n_month:])
-        pylab.setp(pylab.xticks()[1], rotation=20)
-        pylab.gca().xaxis.set_major_formatter(matplotlib.dates.DateFormatter('%b %d %Y'))
-        pylab.xlabel('Date');
-        pylab.ylabel('Minutes played');
-        pylab.title('Play minutes per day this month')
-        pylab.savefig('img/server_day_month.png')
-        pylab.clf()
-
-        # playtime by day (current week)
-        pylab.plot(date_tag[-n_week:], playtime[-n_week:])
-        pylab.setp(pylab.xticks()[1], rotation=20)
-        pylab.gca().xaxis.set_major_formatter(matplotlib.dates.DateFormatter('%b %d %Y'))
-        pylab.gca().xaxis.set_major_locator(matplotlib.ticker.MaxNLocator(n_week+1))
-        pylab.gca().xaxis.set_minor_locator(matplotlib.ticker.MaxNLocator(1))
-        matplotlib.ticker.MaxNLocator
-        pylab.xlabel('Date');
-        pylab.ylabel('Minutes played');
-        pylab.title('Play minutes per day this week')
-        pylab.savefig('img/server_day_week.png')
         pylab.clf()
 
         # plot weekday pie chart

--- a/mclogalyzer/template.html
+++ b/mclogalyzer/template.html
@@ -135,9 +135,9 @@
 					<ul class="nav navbar-nav">
 						<li class="active"><a class="js-link" data-page="page-players" href="#players">Players</a></li>
 						<li>               <a class="js-link" data-page="page-server"  href="#server">Server</a></li>
-            {% if chats|length %}
+						{% if chats|length %}
 						<li>               <a class="js-link" data-page="page-chat"    href="#chat">Chat</a></li>
-            {% endif %}
+						{% endif %}
 					</ul>
 					<ul class="nav navbar-nav navbar-right">
 						<li><span class="navbar-text navbar-right">Last update: {{ last_update }}</span></li>
@@ -322,6 +322,17 @@
 									<li>{{ a }}</li>
 								{% endfor %}
 							</ul></td>
+						</tr>
+						{% endif %}
+						{% if server.include_figures %}
+						<tr>
+							<td colspan="2"><img src="img/{{ user.username }}_weekday_pie.png"/></td>
+						</tr>
+						<tr>
+							<td colspan="2"><img src="img/{{ user.username }}_daytime_dist.png"/></td>
+						</tr>
+						<tr>
+							<td colspan="2"><img src="img/{{ user.username }}_day_history.png"/></td>
 						</tr>
 						{% endif %}
 					</table>

--- a/mclogalyzer/template.html
+++ b/mclogalyzer/template.html
@@ -218,6 +218,17 @@
 						<th>Maximum online players:</th>
 						<td>{{ server.max_players }} ({{ server.max_players_date }})</td>
 					</tr>
+					{% if server.include_figures %}
+					<tr>
+						<td colspan="2"><img src="img/server_weekday_pie.png"/></td>
+					</tr>
+					<tr>
+						<td colspan="2"><img src="img/server_daytime_dist.png"/></td>
+					</tr>
+					<tr>
+						<td colspan="2"><img src="img/server_day_history.png"/></td>
+					</tr>
+					{% endif %}
 				</table>
 			</div>
 			<div id="page-chat" class="page row">
@@ -324,7 +335,7 @@
 							</ul></td>
 						</tr>
 						{% endif %}
-						{% if server.include_figures %}
+						{% if user.include_figures %}
 						<tr>
 							<td colspan="2"><img src="img/{{ user.username }}_weekday_pie.png"/></td>
 						</tr>

--- a/mclogalyzer/template.html
+++ b/mclogalyzer/template.html
@@ -228,6 +228,9 @@
 					<tr>
 						<td colspan="2"><img src="img/server_day_history.png"/></td>
 					</tr>
+					<tr>
+						<td colspan="2"><img src="img/server_day_users.png"/></td>
+					</tr>
 					{% endif %}
 				</table>
 			</div>

--- a/mclogalyzer/template.html
+++ b/mclogalyzer/template.html
@@ -37,6 +37,8 @@
 			[".c-last-login", "Last login", false],
 			[".c-longest-session", "Longest session", false],
 			[".c-deaths", "Deaths", false],
+			[".c-pvp-kills", "PvP kills", false],
+			[".c-pvp-deaths", "PvP deaths", false],
 			[".c-ragequits", "Rage quits", false],
 			[".c-achievements", "Achievements", false],
 			[".c-active-days", "Active days", false],
@@ -164,6 +166,8 @@
 								<th class="col c-last-login">Last login</th>
 								<th class="col c-longest-session">Longest session</th>
 								<th class="col c-deaths">Deaths</th>
+								<th class="col c-pvp-kills">PvP Kills</th>
+								<th class="col c-pvp-deaths">PvP Deaths</th>
 								<th class="col c-ragequits">Rage quits</th>
 								<th class="col c-achievements">Achievements</th>
 								<th class="col c-active-days">Active days</th>
@@ -188,6 +192,8 @@
 								<td class="col c-last-login">{{ user.last_login }}</td>
 								<td class="col c-longest-session">{{ user.longest_session }}</td>
 								<td class="col c-deaths">{{ user.death_count }}</td>
+								<td class="col c-pvp-kills">{{ user.pvp_kills }}</td>
+								<td class="col c-pvp-deaths">{{ user.pvp_deaths }}</td>
 								<td class="col c-ragequits">{{ user.ragequit_count }}</td>
 								<td class="col c-achievements">{{ user.achievement_count }}</td>
 								<td class="col c-active-days">{{ user.active_days }}</td>
@@ -230,6 +236,9 @@
 					</tr>
 					<tr>
 						<td colspan="2"><img src="img/server_day_users.png"/></td>
+					</tr>
+					<tr>
+						<td colspan="2"><img src="img/server_day_pvp.png"/></td>
 					</tr>
 					{% endif %}
 				</table>
@@ -320,6 +329,14 @@
 							</td>
 						</tr>
 						{% endif %}
+						<tr>
+							<th>PvP Kills:</th>
+							<td>{{ user.pvp_kills}}</td>
+						</tr>
+						<tr>
+							<th>PvP Deaths:</th>
+							<td>{{ user.pvp_deaths}}</td>
+						</tr>
 						<tr>
 							<th>Rage quits:</th>
 							<td>{{ user.ragequit_count}}</td>


### PR DESCRIPTION
Creates a series of figures displaying the following use statistic:

* Weekday playtime distribution (per user)
* Weekday playtime distribution (serverwide)
* Clock hour playtime distribution (per user)
* Clock hour playtime distribution (serverwide)
* Date playtime distribution (per user)
* Date playtime distribution (serverwide)
* PvP kills per day (serverwide)
* Active users per day (serverwide)

The figures are created as static images using matplotlib and stored in the "img" folder.

In addition to figures, PvP kills and deaths are added to user statistics.

![minecraft server log statistics - mozilla firefox_001](https://cloud.githubusercontent.com/assets/3500376/8622061/800763ba-2729-11e5-9506-42fe6d69476d.png)
![minecraft server log statistics - mozilla firefox_002](https://cloud.githubusercontent.com/assets/3500376/8622059/800569e8-2729-11e5-949b-34365e9340be.png)
![minecraft server log statistics - mozilla firefox_003](https://cloud.githubusercontent.com/assets/3500376/8622060/8006205e-2729-11e5-9552-da772b2d9a77.png)

The figures are disabled by default, and is toggled on by the  "--figures" flag. The creation of figures is now typically the most time-consuming part of the script.